### PR TITLE
Fix decreaseMinutes bug

### DIFF
--- a/src/ionic-timepicker.directive.js
+++ b/src/ionic-timepicker.directive.js
@@ -88,7 +88,7 @@
 
         scope.decreaseMinutes = function () {
           scope.time.minutes = Number(scope.time.minutes);
-          if (scope.time.minutes != 0 && (scope.time.minutes - obj.step > 0)) {
+          if (scope.time.minutes != 0 && (scope.time.minutes - obj.step >= 0)) {
             scope.time.minutes -= obj.step;
           } else {
             scope.time.minutes = 60 - obj.step;


### PR DESCRIPTION
currently, `decreaseMinutes` method never sets `time.minutes` to 0.
for example, when `step` = 15, `time.minutes` will change like this:
0 -> 45 -> 30 -> 15 -> 45 -> 30 -> 15 -> ...

after this patch:
0 -> 45 -> 30 -> 15 -> 0 -> 45 -> 30 -> 15 -> ...
