### PR TITLE
Fix syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "rajeshwarpatlolla <rajeshwar.patlolla@gmail.com>"
   ],
   "description": "A time picker for IONIC framework",
-  "main": [
-    "./dist/ionic-timepicker.bundle.min.js"
-  ],
+  "main": "./dist/ionic-timepicker.bundle.min.js",
   "scripts": {},
   "author": "https://github.com/rajeshwarpatlolla, rajeshwar.patlolla@gmail.com",
   "license": "MIT",


### PR DESCRIPTION
Before it was using `bower.json` like array syntax

Same fix as in https://github.com/rajeshwarpatlolla/ionic-datepicker/pull/160
